### PR TITLE
Add configurable rate limit for moderation API requests

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -112,6 +112,13 @@
                 "type": "bool",
                 "help_text": "When true, content moderation actions will be logged to the audit log for compliance tracking. Note: This setting has no effect unless audit logging is configured at the server level.",
                 "default": true
+            },
+            {
+                "key": "rateLimitPerMinute",
+                "display_name": "Rate Limit (requests per minute)",
+                "type": "number",
+                "help_text": "Maximum number of moderation API requests per minute. Default is 500 for Azure AI Content Safety.",
+                "default": 500
             }
         ]
     }

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -26,6 +26,7 @@ type configuration struct {
 	ExcludePrivateChannels bool   `json:"excludePrivateChannels"`
 	BotUsername            string `json:"botUsername"`
 	AuditLoggingEnabled    bool   `json:"auditLoggingEnabled"`
+	RateLimitPerMinute     int    `json:"rateLimitPerMinute"`
 
 	Type string `json:"type"`
 
@@ -58,6 +59,14 @@ func (c *configuration) ThresholdValue() (int, error) {
 		return 0, errors.Wrapf(err, "could not parse threshold value: '%s'", c.Threshold)
 	}
 	return val, nil
+}
+
+// RateLimitValue returns the rate limit per minute as an integer
+func (c *configuration) RateLimitValue() int {
+	if c.RateLimitPerMinute <= 0 {
+		return 500 // Default rate limit
+	}
+	return c.RateLimitPerMinute
 }
 
 // Clone shallow copies the configuration. Your implementation may require a deep copy if
@@ -112,7 +121,8 @@ func (p *Plugin) setConfiguration(configuration *configuration) {
 		"excludePrivateChannels", configuration.ExcludePrivateChannels,
 		"moderationThreshold", configuration.Threshold,
 		"auditLoggingEnabled", configuration.AuditLoggingEnabled,
-		"botUsername", configuration.BotUsername)
+		"botUsername", configuration.BotUsername,
+		"rateLimitPerMinute", configuration.RateLimitPerMinute)
 
 	p.configuration = configuration
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -75,7 +75,8 @@ func (p *Plugin) initialize(config *configuration) error {
 	}
 
 	moderationResultsCache := newModerationResultsCache()
-	moderationProcessor, err := newModerationProcessor(moderationResultsCache, moderator, thresholdValue)
+	rateLimitPerMinute := config.RateLimitValue()
+	moderationProcessor, err := newModerationProcessor(moderationResultsCache, moderator, thresholdValue, rateLimitPerMinute)
 	if err != nil {
 		return errors.Wrap(err, "failed to create post moderation processor")
 	}


### PR DESCRIPTION
- Add rateLimitPerMinute configuration option with default of 500
- Update ModerationProcessor to use configurable processing interval
- Allow customization based on environment and provider limits

Fixes #24

🤖 Generated with [Claude Code](https://claude.ai/code)